### PR TITLE
Fix redundant escaping in search queries

### DIFF
--- a/application/models/Breeds_model.php
+++ b/application/models/Breeds_model.php
@@ -46,7 +46,7 @@ class Breeds_model extends MY_Model
 				owners.id = pets.owner
 
 			WHERE
-				breeds.name LIKE '" . $this->db->escape_like_str($query) . "%' ESCAPE '!'
+                               breeds.name LIKE '" . $query . "%' ESCAPE '!'
 			AND
 				pets.death = 0
 			AND

--- a/application/models/Owners_model.php
+++ b/application/models/Owners_model.php
@@ -81,7 +81,7 @@ class Owners_model extends MY_Model
 			FROM 
 				owners
 			WHERE
-				street LIKE '%" . $this->db->escape_like_str($street) . "%' ESCAPE '!'
+				street LIKE '%" . $street . "%' ESCAPE '!'
 			ORDER BY
 				last_bill
 			DESC

--- a/application/models/Pets_model.php
+++ b/application/models/Pets_model.php
@@ -77,7 +77,7 @@ class Pets_model extends MY_Model
 			ON
 				owners.id = pets.owner
 			WHERE
-				name LIKE '" . $this->db->escape_like_str($query) . "%' ESCAPE '!'
+				name LIKE '" . $query . "%' ESCAPE '!'
 				" . ($dead_allowed ? "" : "AND pets.death = 0") . "
 			ORDER BY
 				owners.last_bill


### PR DESCRIPTION
## Summary
- fix double escaping when searching by street for owners
- reuse escaped search text when filtering pets and breeds by name

## Testing
- php -l application/models/Owners_model.php
- php -l application/models/Pets_model.php
- php -l application/models/Breeds_model.php

------
https://chatgpt.com/codex/tasks/task_b_68d3adce1cc88322ba20a52e7d49aa15